### PR TITLE
Add support for receipts-space.com

### DIFF
--- a/Support/bin/add
+++ b/Support/bin/add
@@ -10,7 +10,10 @@ cat > "${TMPFILE}"
 
 BUNDLEID="" # bundle identifier to run Receipts.app from.
 
-if [[ -d /Applications/Receipts.app ]]
+if [[ -d /Applications/Receipts Spase.app ]]
+then
+	BUNDLEID='de.holtwick.mac.appstore.Receipts2'
+elif [[ -d /Applications/Receipts.app ]]
 then
 	BUNDLEID='com.apperdeck.mac.Receipts'
 elif [[ -d /Applications/Setapp/Receipts.app ]]

--- a/Support/bin/add
+++ b/Support/bin/add
@@ -10,7 +10,7 @@ cat > "${TMPFILE}"
 
 BUNDLEID="" # bundle identifier to run Receipts.app from.
 
-if [[ -d /Applications/Receipts Spase.app ]]
+if [[ -d "/Applications/Receipts Space.app" ]]
 then
 	BUNDLEID='de.holtwick.mac.appstore.Receipts2'
 elif [[ -d /Applications/Receipts.app ]]


### PR DESCRIPTION
The next version of Receipts is coming soon, see https://receipts-space.com/beta for details. 

Added the new app name and bundle ID. Would be great, if this could be updated.